### PR TITLE
:bug:(index) ignore empty public path when create

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class MyCustomReporter {
       publicPath = process.cwd(),
       filename = 'jest_html_reporters.html'
     } = this._options
-    fs.existsSync(publicPath) === false && mkdirs(publicPath)
+    fs.existsSync(publicPath) === false && publicPath && mkdirs(publicPath)
     const filePath = path.resolve(publicPath, filename)
     const htmlTemplate = fs.readFileSync(localTemplatePath, 'utf-8')
     const outPutContext = htmlTemplate


### PR DESCRIPTION
mkdirs/1 will failed if publicPath set to empth string which is a common case from v1.1.2