### PR TITLE
Tets title including the `describe` block name

### DIFF
--- a/src/components/DetailTable.js
+++ b/src/components/DetailTable.js
@@ -41,12 +41,18 @@ const renderTitleContent = (title = '') => {
   return title
 }
 
-const renderTitle = (title, { fullName }) => <Tooltip overlayStyle={{ maxWidth: '800px' }} title={fullName}>
-  <span className='inner_path_text'>{renderTitleContent(title)}</span>
-</Tooltip>
+const renderTitle = ({ ancestorTitles = [], title, fullName }) => {
+  const sep = ' > '
+  const nestedTitle = [...ancestorTitles, title].join(sep)
+  return (
+    <Tooltip overlayStyle={{ maxWidth: '800px' }} title={fullName}>
+      <span className='inner_path_text'>{renderTitleContent(nestedTitle)}</span>
+    </Tooltip>
+  )
+}
 
 const columns = [
-  { title: 'title', dataIndex: 'title', render: renderTitle },
+  { title: 'title', key: 'Name', render: renderTitle },
   { title: 'UseTime', key: 'UseTime', render: renderTime, width: '150px' },
   { title: 'status', dataIndex: 'status', render: renderStatus, align: 'center', width: '150px' },
   {

--- a/test/components/testDetailTable.spec.js
+++ b/test/components/testDetailTable.spec.js
@@ -21,3 +21,70 @@ describe('test DetailTable ', () => {
     expect(wrapper.find(ErrorButton)).toExist()
   })
 })
+
+test('Top level test in a file', () => {
+  const title = 'top level test'
+  const mockProps = {
+    data: [
+      {
+        ancestorTitles: [],
+        fullName: title,
+        title,
+        status: 'passed',
+        duration: 2,
+        failureMessages: [],
+      },
+    ],
+  }
+  const wrapper = mount(<DetailTable {...mockProps} />)
+  expect(wrapper.text()).toEqual(expect.stringMatching(title))
+})
+
+describe('Nested describes', () => {
+  test('Tope level test in a describe should be prepended by describe name', () => {
+    const describeTitle = 'Nested describes'
+    const title = 'top level describe test'
+    const mockProps = {
+      data: [
+        {
+          ancestorTitles: [describeTitle],
+          fullName: `${describeTitle} > ${title}`,
+          title,
+          status: 'passed',
+          duration: 2,
+          failureMessages: [],
+        },
+      ],
+    }
+    const wrapper = mount(<DetailTable {...mockProps} />)
+    expect(wrapper.text()).toEqual(
+      expect.stringMatching(`${describeTitle} > ${title}`),
+    )
+  })
+
+  describe('Secondary describe', () => {
+    const describeTitle1 = 'Nested describes'
+    const describeTitle2 = 'Secondary describe'
+    const title = 'secondary describe test'
+    const mockProps = {
+      data: [
+        {
+          ancestorTitles: [describeTitle1, describeTitle2],
+          fullName: [describeTitle1, describeTitle2, title].join(' '),
+          title,
+          status: 'passed',
+          duration: 2,
+          failureMessages: [],
+        },
+      ],
+    }
+    test('Secondary test should be prepended by describe name', () => {
+      const wrapper = mount(<DetailTable {...mockProps} />)
+      expect(wrapper.text()).toEqual(
+        expect.stringMatching(
+          [describeTitle1, describeTitle2, title].join(' > '),
+        ),
+      )
+    })
+  })
+})


### PR DESCRIPTION
This is one solution for issue #6 . Ideally we should be able to nest test results under describes, which in turn would be nested under file results, but the output from the native jest reporter doesn't really have that structure, and it would be necessary to additionally aggregate results under describes and create some sort of recursive structure.
This PR simply joins the `ancestorTitles` and a title with a ` > ` as in the https://www.npmjs.com/package/jest-html-reporter. 
![Like this](https://user-images.githubusercontent.com/17745246/57972460-d22f1d80-7992-11e9-873a-9a84c2b375a8.jpg)
This might be an issue for someone, because of the character limit, the test name now is pushed to the end and might end after the ellipsis, so one would have to hover to see the title with the test name. 
But yeah anyway that's like the lowest effort fix. 
 