### PR TITLE
Add optional parameter *context* to addAttach and addMsg

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -11,8 +11,8 @@ const distDirName = `./jest-html-reporters-attach`;
  * @param {Buffer | string} attach
  * @param {string} description
  */
-const addAttach = async (attach, description) => {
-  const { testPath, testName } = getJestGlobalData();
+const addAttach = async (attach, description, context) => {
+  const { testPath, testName } = getJestGlobalData(context);
   // type check
   if (typeof attach !== "string" && !Buffer.isBuffer(attach)) {
     console.error(
@@ -50,19 +50,20 @@ const addAttach = async (attach, description) => {
  *
  * @param {string} message
  */
-const addMsg = async (message) => {
-  const { testPath, testName } = getJestGlobalData();
+const addMsg = async (message, context) => {
+  const { testPath, testName } = getJestGlobalData(context);
   const fileName = generateRandomString();
   const attachObject = { testPath, testName, description: message };
   await fs.writeJSON(`${dataDirPath}/${fileName}.json`, attachObject);
 };
 
-const getJestGlobalData = () => {
+const getJestGlobalData = (globalContext) => {
   let testPath = "";
   let currentTestName = "";
-  [...Object.getOwnPropertySymbols(global)].forEach((key) => {
-    if (global[key].state && global[key].matchers) {
-      const state = global[key].state || {};
+  const context = globalContext || global;
+  [...Object.getOwnPropertySymbols(context)].forEach((key) => {
+    if (context[key].state && context[key].matchers) {
+      const state = context[key].state || {};
       testPath = state.testPath;
       currentTestName = state.currentTestName;
     }

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ This feature regrading to [#36](https://github.com/Hazyzh/jest-html-reporters/is
  *
  * @param {Buffer | string} attach
  * @param {string} description of the picture
- * @param {object} description of the picture
+ * @param {object} custom context (optional)
  */
 const addAttach = async (attach, description, context) => { ... }
 ```
@@ -149,6 +149,7 @@ This feature is in regards to [#63](https://github.com/Hazyzh/jest-html-reporter
 /**
  *
  * @param {string} message
+ * @param {object} custom context (optional)
  */
 const addMsg = async (message, context) => { ... }
 ```

--- a/readme.md
+++ b/readme.md
@@ -88,11 +88,14 @@ This feature regrading to [#36](https://github.com/Hazyzh/jest-html-reporters/is
  *
  * @param {Buffer | string} attach
  * @param {string} description of the picture
+ * @param {object} description of the picture
  */
-const addAttach = async (attach, description) => { ... }
+const addAttach = async (attach, description, context) => { ... }
 ```
 
-There are two params of this method, `description` is easy to understand. The param **`attach`** referring to the image, you can pass a `buffer` or `string`, if it was a buffer the package will help you create a dir named `jest-html-reporters-attach` and save that `buffer` as a `jpg` image in it under the `publicPath`. if you have already saved the image, just pass the image's path as the `attach` param.
+There are three params of this method, `description` is easy to understand. The param **`attach`** referring to the image, you can pass a `buffer` or `string`, if it was a buffer the package will help you create a dir named `jest-html-reporters-attach` and save that `buffer` as a `jpg` image in it under the `publicPath`. if you have already saved the image, just pass the image's path as the `attach` param.
+`context` is optional parameter if you need add a specific context to attachment(like test path or name).
+
 Here is an Example with [puppeteer](https://github.com/puppeteer/puppeteer).
 
 ```javascript
@@ -147,10 +150,11 @@ This feature is in regards to [#63](https://github.com/Hazyzh/jest-html-reporter
  *
  * @param {string} message
  */
-const addMsg = async (message) => { ... }
+const addMsg = async (message, context) => { ... }
 ```
 
-Only one parameter is required. If you stringify an object like this `JSON.stringify(object, null, 2)`, the object will be prettified
+Only one parameter is required. If you stringify an object like this `JSON.stringify(object, null, 2)`, the object will be prettified.
+`context` is optional parameter if you need add a specific context to message(like test path or name).
 
 Here is an Example with [Nightmare](https://www.npmjs.com/package/nightmare).
 


### PR DESCRIPTION
Hi all.
I tried to use jest-html-reporters + jest-circus + playwright(https://github.com/microsoft/playwright). 
It works pretty well, excludes some specific cases. I wanted to add a handle for failure tests like
```
async handleTestEvent(event, state) {
   if (event.name === 'test_fn_failure' ) {
      const screenshotBuffer = await this.global.page.screenshot();
      await addAttach(screenshotBuffer, testName, this.global);
  }
}
```
but in this case *jest-html-reporter* loosing global context of the test in `getJestGlobalData` and the screenshot can't be attached properly to report.
As a solution, I want to suggest to add an ability to pass a custom context