### PR TITLE
fix(customtooltip): prevent exception when payload is empty

### DIFF
--- a/src/components/Information.js
+++ b/src/components/Information.js
@@ -34,7 +34,7 @@ import {
 const colors = [...new Array(40)].map((d) => randomColor());
 
 const CustomTooltip = ({ active, payload, label, rootDir, chartTooltip }) => {
-  if (active) {
+  if (active && Array.isArray(payload) && !!payload[0] && !!payload[0].payload) {
     const {
       time,
       name,


### PR DESCRIPTION
This PR fixes edge cases when payload is not fully defined customtooltip exception makes fail to render. This was observable when `failureMessageOnly: true` on jest@27.