### PR TITLE
Added fourth option to addAttach to allow specifying attachment filetype.

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -18,7 +18,7 @@ const distDirName = `./jest-html-reporters-attach`;
  * @param {string} description
  * @param {object} context. Optional. It contains custom configs
  */
-const addAttach = async (attach, description, context) => {
+const addAttach = async (attach, description, context, bufferFormat) => {
   const { testPath, testName } = getJestGlobalData(context);
   // type check
   if (typeof attach !== "string" && !Buffer.isBuffer(attach)) {
@@ -35,16 +35,17 @@ const addAttach = async (attach, description, context) => {
   }
 
   if (Buffer.isBuffer(attach)) {
-    const path = `${attachDirPath}/${fileName}.jpg`;
+    bufferFormat = bufferFormat || 'jpg'
+    const path = `${attachDirPath}/${fileName}.${bufferFormat}`;
     try {
       await fs.writeFile(path, attach);
       const attachObject = {
         testPath,
         testName,
-        fileName: `${fileName}.jpg`,
+        fileName: `${fileName}.${bufferFormat}`,
         description,
       };
-      await fs.writeJSON(`${dataDirPath}/${fileName}.json`, attachObject);
+      await fs.writeJSON(`${dataDirPath}/${fileName}.${bufferFormat}`, attachObject);
     } catch (err) {
       console.error(err);
       console.error(


### PR DESCRIPTION
Previously, the only filetype that could be attached with addAttach via buffer was jpg. Everything else would be saved as a .jpg and then served into the HTML as a jpg. 

Now you can specify the filetype allowing attachments to be png, svg, gif, etc.
Behaviour remains the same if this option is not specified