### PR TITLE
corrupted report fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,9 +104,8 @@ class MyCustomReporter {
     // fs.writeFileSync('./src/devMock.json', data)
     if (!multipleReportsUnitePath) {
       const htmlTemplate = fs.readFileSync(localTemplatePath, "utf-8");
-      const outPutContext = htmlTemplate.replace(
-        "$resultData",
-        JSON.stringify(data).replace(/['"]/g, "")
+      const outPutContext = htmlTemplate.replace("$resultData", () =>
+        JSON.stringify(data)
       );
       fs.writeFileSync(filePath, outPutContext, "utf-8");
       console.log("📦 reporter is created on:", filePath);

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ class MyCustomReporter {
       const htmlTemplate = fs.readFileSync(localTemplatePath, "utf-8");
       const outPutContext = htmlTemplate.replace(
         "$resultData",
-        JSON.stringify(data)
+        JSON.stringify(data).replace(/'\$'/g, "$")
       );
       fs.writeFileSync(filePath, outPutContext, "utf-8");
       console.log("📦 reporter is created on:", filePath);

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ class MyCustomReporter {
       const htmlTemplate = fs.readFileSync(localTemplatePath, "utf-8");
       const outPutContext = htmlTemplate.replace(
         "$resultData",
-        JSON.stringify(data).replace(/'\$'/g, "$")
+        JSON.stringify(data).replace(/'(.*)\$(.*)'/g, "$1$$2")
       );
       fs.writeFileSync(filePath, outPutContext, "utf-8");
       console.log("📦 reporter is created on:", filePath);

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ class MyCustomReporter {
       const htmlTemplate = fs.readFileSync(localTemplatePath, "utf-8");
       const outPutContext = htmlTemplate.replace(
         "$resultData",
-        JSON.stringify(data).replace(/'(.*)\$(.*)'/g, "$1$$2")
+        JSON.stringify(data).replace(/['"]/g, "")
       );
       fs.writeFileSync(filePath, outPutContext, "utf-8");
       console.log("📦 reporter is created on:", filePath);


### PR DESCRIPTION
This should fixes the issue described here:
https://github.com/Hazyzh/jest-html-reporters/issues/97

It also happens when console message includes ` TypeError: Cannot read property '$' of null` while running tests with puppeteer/playwright and handler is undefined.

I come up with this solution, at least it can give you some ideas.