### PR TITLE
Add hour data while displaying time duration

### DIFF
--- a/src/untils/index.js
+++ b/src/untils/index.js
@@ -41,11 +41,14 @@ const InsuranceNumber = (number, minLength = 2) => {
  */
 export const getFormatTime = (start, end) => {
   const duration = moment.duration(end - start)
+  const hour = InsuranceNumber(duration.hours())
   const min = InsuranceNumber(duration.minutes())
   const sec = InsuranceNumber(duration.seconds())
   const msec = InsuranceNumber(duration.milliseconds(), 3)
   let node
-  if (min !== '00') {
+  if (hour !== '00') {
+    node = <span className='time_active'>{`${hour}:${min}:${sec}.${msec}`}</span>
+  } else if (min !== '00') {
     node = <span className='time_active'>{`${min}:${sec}.${msec}`}</span>
   } else if (sec !== '00') {
     node = <span>


### PR DESCRIPTION
Fix for https://github.com/Hazyzh/jest-html-reporters/issues/134

@Hazyzh Great work with the HTML reporter. 

I use your plugin for running Puppeteer UI tests which takes more than an hour to complete. So, would be great to have the hour information as well while displaying time duration.


P.S: This is my first contribution to a public repository. I am not sure if i have to add a test for this change. 
Kindly suggest your comments.