### PR TITLE
fix: 🐛 remove resource dir when using inline source

### DIFF
--- a/helper.ts
+++ b/helper.ts
@@ -109,7 +109,7 @@ const getJestGlobalData = (globalContext) => {
 const generateRandomString = () => `${Date.now()}${Math.random()}`;
 
 export const readAttachInfos = async (publicPath: string, publicRelativePath: string) => {
-  const result = {};
+  const result: any = {};
   try {
     const exist = await fs.pathExists(dataDirPath);
 
@@ -127,7 +127,10 @@ export const readAttachInfos = async (publicPath: string, publicRelativePath: st
       )
     );
     const attachFiles = await fs.readdir(attachDirPath);
-    if (attachFiles.length) await fs.copy(attachDirPath, publicPath);
+    if (attachFiles.length) {
+      result.hasAttachFiles = true;
+      await fs.copy(attachDirPath, publicPath)
+    };
 
     dataList.forEach((attachObject) => {
       if (!attachObject) return;

--- a/index.ts
+++ b/index.ts
@@ -121,7 +121,6 @@ class MyCustomReporter {
         openBrowser(filePath, openReport === true ? {} : openReport);
       }
     };
-    console.log('attachInfos', attachInfos);
     results.attachInfos = attachInfos;
     fs.existsSync(publicPath) === false && publicPath && mkdirs(publicPath);
 

--- a/index.ts
+++ b/index.ts
@@ -121,6 +121,7 @@ class MyCustomReporter {
         openBrowser(filePath, openReport === true ? {} : openReport);
       }
     };
+    console.log('attachInfos', attachInfos);
     results.attachInfos = attachInfos;
     fs.existsSync(publicPath) === false && publicPath && mkdirs(publicPath);
 
@@ -158,6 +159,13 @@ class MyCustomReporter {
         pattern: packageSingleReplaceReg,
         newSubstr: data
       });
+
+      // remove temp dir
+      if (!attachInfos.hasAttachFiles) {
+        fse.removeSync(
+          path.resolve(this._options.publicPath, resourceDirName)
+        );
+      }
     }
 
     console.log('📦 reporter is created on:', filePath);


### PR DESCRIPTION
remove unused dir
