### PR TITLE
fix: apply break-word to each table cell

### DIFF
--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -15,6 +15,8 @@
 }
 
 .inner_path_text {
+  overflow-wrap: break-word;
+  white-space: normal;
   color: #a7a6a6;
 }
 // code modal


### PR DESCRIPTION
fix #226 

To fully display the test name, I added new css to each table cell.

## Before
<img width="1434" alt="SS_ 2022-07-09 10 03 55" src="https://user-images.githubusercontent.com/17228098/178085927-08d03cd2-2576-4abc-9c3b-eb3d7d5de563.png">


## After
<img width="1439" alt="SS_ 2022-07-09 10 05 12" src="https://user-images.githubusercontent.com/17228098/178085916-dea204fa-a779-4e06-9810-dae8ec687ce3.png">

