### PR TITLE
Add check context[key] is defined before accessing it.

### DIFF
--- a/helper.ts
+++ b/helper.ts
@@ -98,7 +98,7 @@ const getJestGlobalData = (globalContext) => {
   let currentTestName = '';
   const context = globalContext || global;
   [...Object.getOwnPropertySymbols(context)].forEach((key) => {
-    if (context[key].state && context[key].matchers) {
+    if (context[key] && context[key].state && context[key].matchers) {
       const state = context[key].state || {};
       testPath = state.testPath;
       currentTestName = state.currentTestName;


### PR DESCRIPTION
Fixes the following error: 
When `key = Symbol(LOG_ERRORS_BEFORE_RETRY)` `context[key]` is undefined.
```
TypeError: Cannot read properties of undefined (reading 'state')
    at mymodule/node_modules/jest-html-reporters/helper.js:151:26
    at Array.forEach (<anonymous>)
    at getJestGlobalData (mymodule/node_modules/jest-html-reporters/helper.js:150:68)
    at mymodule/node_modules/jest-html-reporters/helper.js:133:26
    at step (mymodule/node_modules/jest-html-reporters/helper.js:33:23)
    at Object.next (mymodule/node_modules/jest-html-reporters/helper.js:14:53)
    at mymodule/node_modules/jest-html-reporters/helper.js:8:71
    at new Promise (<anonymous>)
    at Object.<anonymous>.__awaiter (mymodule/node_modules/jest-html-reporters/helper.js:4:12)
    at Object.addMsg (mymodule/node_modules/jest-html-reporters/helper.js:128:12)
```
`LOG_ERRORS_BEFORE_RETRY` seems to have been added in jest circus here : 
https://github.com/facebook/jest/pull/12201/files#diff-1f219915a2f99fe6ad8b7478a41464c5aaabc4c7e6c1e1f004c59d135aa08e9fR22

