### PR TITLE
Added filter to show only failed tests

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -101,7 +101,7 @@ export const HomePage = ({ data }: { data: IReportData }) => {
             onChange={(checked) => setGlobalExpandState(checked)}
             checked={globalExpandState}
           />
-          <span className='text'>Show only failed</span>
+          <span className='text'>Show Only Failed</span>
           <Switch
             onChange={(checked) => setShowOnlyFailed(checked)}
             checked={showOnlyFailed}


### PR DESCRIPTION
A switch is available to exclude information about passed tests and include only failed tests.

![image](https://github.com/user-attachments/assets/fccc150c-65b1-4c1f-83ab-2166a9376b25)

