### PR TITLE
fix `name too long` error while running tests using Bazel

### DIFF
--- a/helper.ts
+++ b/helper.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 import { AggregatedResult } from '@jest/test-result';
+import { createHash } from 'crypto';
 
 let username: string = '';
 try {
@@ -12,7 +13,7 @@ try {
 
 export const tempDirPath = path.resolve(
   process.env.JEST_HTML_REPORTERS_TEMP_DIR_PATH || os.tmpdir(),
-  `${username}-${Buffer.from(process.cwd()).toString('base64')}`,
+  `${username}-${createHash('sha256').update(Buffer.from(process.cwd())).digest('base64')}`,
   'jest-html-reporters-temp'
 );
 


### PR DESCRIPTION
while running tests using Bazel I was getting following error:
```
Error: An error occurred while adding the reporter at path "/private/var/tmp/_bazel_pleszczewicz/70be9b0265926805fbb6db88234b0bd1/execroot/snowcommand/bazel-out/darwin_arm64-fastbuild/bin/projects/api/node_modules/jest-html-reporters/index.js".
ENAMETOOLONG: name too long, unlink '/var/folders/6r/wcbqqn_s4jzd611qfcgqlx800000gp/T/pleszczewicz-L3ByaXZhdGUvdmFyL3RtcC9fYmF6ZWxfcGxlc3pjemV3aWN6LzcwYmU5YjAyNjU5MjY4MDVmYmI2ZGI4ODIzNGIwYmQxL3NhbmRib3gvZGFyd2luLXNhbmRib3gvNDAvZXhlY3Jvb3Qvc25vd2NvbW1hbmQvYmF6ZWwtb3V0L2Rhcndpbl9hcm02NC1mYXN0YnVpbGQvYmluL3Byb2plY3RzL2FwaS9fX2plc3RfdGVzdHRlc3RfbW9kdWxlX3JiYWNfaW50ZWdyYXRpb24uc2gucnVuZmlsZXMvc25vd2NvbW1hbmQvcHJvamVjdHMvYXBp/jest-html-reporters-temp'
    at unlinkSync (node:fs:1881:3)
    at _unlinkSync (node:internal/fs/rimraf:214:14)
    at rimrafSync (node:internal/fs/rimraf:195:7)
    at Object.rmSync (node:fs:1271:10)
    at Object.removeSync (/private/var/tmp/_bazel_pleszczewicz/70be9b0265926805fbb6db88234b0bd1/execroot/snowcommand/bazel-out/darwin_arm64-fastbuild/bin/projects/api/node_modules/jest-html-reporters/node_modules/fs-extra/lib/remove/index.js:15:28)
    at MyCustomReporter.removeTempDir (/private/var/tmp/_bazel_pleszczewicz/70be9b0265926805fbb6db88234b0bd1/execroot/snowcommand/bazel-out/darwin_arm64-fastbuild/bin/projects/api/node_modules/jest-html-reporters/index.js:229:28)
    at MyCustomReporter.initAttachDir (/private/var/tmp/_bazel_pleszczewicz/70be9b0265926805fbb6db88234b0bd1/execroot/snowcommand/bazel-out/darwin_arm64-fastbuild/bin/projects/api/node_modules/jest-html-reporters/index.js:222:14)
    at MyCustomReporter.init (/private/var/tmp/_bazel_pleszczewicz/70be9b0265926805fbb6db88234b0bd1/execroot/snowcommand/bazel-out/darwin_arm64-fastbuild/bin/projects/api/node_modules/jest-html-reporters/index.js:205:14)
    at new MyCustomReporter (/private/var/tmp/_bazel_pleszczewicz/70be9b0265926805fbb6db88234b0bd1/execroot/snowcommand/bazel-out/darwin_arm64-fastbuild/bin/projects/api/node_modules/jest-html-reporters/index.js:113:14)
    at TestScheduler._addCustomReporter (/private/var/tmp/_bazel_pleszczewicz/70be9b0265926805fbb6db88234b0bd1/execroot/snowcommand/bazel-out/darwin_arm64-fastbuild/bin/projects/api/node_modules/@jest/core/build/TestScheduler.js:390:9)
```
this PR will fix this issue