### PR TITLE
fix: sanitize custom attachment file names

### DIFF
--- a/helper.ts
+++ b/helper.ts
@@ -13,7 +13,7 @@ try {
 
 export const tempDirPath = path.resolve(
   process.env.JEST_HTML_REPORTERS_TEMP_DIR_PATH || os.tmpdir(),
-  `${username}-${createHash('sha256').update(Buffer.from(process.cwd())).digest('base64')}`,
+  `${username}-${createHash('sha256').update(Buffer.from(process.cwd())).digest('hex')}`,
   'jest-html-reporters-temp'
 );
 
@@ -58,11 +58,9 @@ export const addAttach = async ({
     return;
   }
   const createTime = Date.now();
-  var fileName;
-  if (!fileCustomName)
-    fileName = generateRandomString();
-  else
-    fileName = fileCustomName;
+  const fileName = await getAvailableAttachFileName(
+    fileCustomName ? getSafeFileName(fileCustomName) : generateRandomString()
+  );
   if (typeof attach === 'string') {
     const attachObject: TAttachObject = {
       createTime,
@@ -135,6 +133,28 @@ const getJestGlobalData = (globalContext) => {
 };
 
 const generateRandomString = () => `${Date.now()}${Math.random()}`;
+
+const getSafeFileName = (fileName: string) => {
+  const parsedName = path.parse(path.basename(fileName)).name;
+  const safeName = parsedName
+    .replace(/[^a-zA-Z0-9._-]/g, '_')
+    .replace(/^\.+/, '')
+    .slice(0, 120);
+
+  return safeName || generateRandomString();
+};
+
+const getAvailableAttachFileName = async (fileName: string) => {
+  let nextFileName = fileName;
+  let index = 1;
+
+  while (await fs.pathExists(`${dataDirPath}/${nextFileName}.json`)) {
+    nextFileName = `${fileName}-${index}`;
+    index += 1;
+  }
+
+  return nextFileName;
+};
 
 export const readAttachInfos = async (
   publicPath: string,

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -1,0 +1,49 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import {
+  addAttach,
+  attachDirPath,
+  dataDirPath,
+  tempDirPath,
+} from '../helper';
+
+describe('helper attachment paths', () => {
+  beforeEach(async () => {
+    await fs.remove(dataDirPath);
+    await fs.remove(attachDirPath);
+    await fs.ensureDir(dataDirPath);
+    await fs.ensureDir(attachDirPath);
+  });
+
+  afterAll(async () => {
+    await fs.remove(dataDirPath);
+    await fs.remove(attachDirPath);
+  });
+
+  test('uses a path-safe hash for the temp directory name', () => {
+    const hash = path.basename(path.dirname(tempDirPath)).split('-').pop();
+
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test('sanitizes custom attachment names and avoids overwriting duplicates', async () => {
+    await addAttach({
+      attach: Buffer.from('first'),
+      description: 'first',
+      bufferFormat: 'png',
+      fileCustomName: '../unsafe name.png',
+    });
+    await addAttach({
+      attach: Buffer.from('second'),
+      description: 'second',
+      bufferFormat: 'png',
+      fileCustomName: '../unsafe name.png',
+    });
+
+    expect(await fs.pathExists(path.join(attachDirPath, 'unsafe_name.png'))).toBe(true);
+    expect(await fs.pathExists(path.join(attachDirPath, 'unsafe_name-1.png'))).toBe(true);
+    expect(await fs.pathExists(path.join(dataDirPath, 'unsafe_name.json'))).toBe(true);
+    expect(await fs.pathExists(path.join(dataDirPath, 'unsafe_name-1.json'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- use a path-safe hex hash for the reporter temp directory
- sanitize fileCustomName before using it as an attachment file name
- avoid overwriting attachment metadata when a custom name is reused
- add focused regression coverage for the two fixes

## Test
- ./node_modules/.bin/tsc -p build
- ./node_modules/.bin/jest test/helper.spec.js --runInBand --reporters=default