### PR TITLE
fix: restore root type declaration packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "version": "3.1.7",
   "description": "Jest test results processor for generating a summary in HTML",
   "main": "index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "build": "yarn tsc -p build && node scripts/build.js",
     "buildCi": "yarn tsc -p build && node scripts/build.js",
     "start": "node scripts/start.js",
     "test": "yarn tsc -p build && node scripts/test.js",
     "testCi": "yarn tsc -p build && node scripts/test.js --reporters=default",
+    "test:package": "node scripts/verifyPackageFiles.js",
     "commit": "cz",
     "pr": "gh pr create"
   },
@@ -138,6 +140,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "helper.js",
     "readme.md",
     "dist/index.html",

--- a/scripts/verifyPackageFiles.js
+++ b/scripts/verifyPackageFiles.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+const pkg = require('../package.json');
+
+const normalize = (value) => value && value.replace(/^\.\//, '');
+const packageFiles = new Set((pkg.files || []).map(normalize));
+
+if (fs.existsSync(path.join(__dirname, '..', 'index.ts'))) {
+  const typesEntry = normalize(pkg.types || pkg.typings);
+  if (typesEntry !== 'index.d.ts') {
+    throw new Error('package.json must expose the generated index.d.ts types');
+  }
+}
+
+const requiredFiles = [pkg.main, pkg.types, pkg.typings].filter(Boolean);
+
+for (const file of requiredFiles) {
+  const normalized = normalize(file);
+  if (!packageFiles.has(normalized)) {
+    throw new Error(
+      `package.json files must include ${normalized} referenced by package metadata`
+    );
+  }
+}
+
+console.log(
+  `Verified package metadata files: ${requiredFiles
+    .map((file) => path.posix.normalize(normalize(file)))
+    .join(', ')}`
+);


### PR DESCRIPTION
## Summary
- restore the root `types` entry for the reporter package
- include the generated `index.d.ts` in the npm `files` whitelist
- add a package metadata check so declared entry files remain included in future packs

## Why
The published `jest-html-reporters@3.1.7` metadata points TypeScript consumers at `./index.d.ts`, but the npm tarball does not include that file. The build already generates `index.d.ts`; this keeps the package metadata and published file whitelist aligned.

## Validation
- `node scripts/verifyPackageFiles.js` failed before the fix because the root type declaration was not exposed
- `npx tsc -p build`
- `node scripts/verifyPackageFiles.js`
- `node scripts/test.js --runInBand --reporters=default`
- `node scripts/build.js`
- `npm pack --ignore-scripts --json .` and verified `index.d.ts` is included in the tarball
- `git diff --check`