### PR TITLE
fix: render data URI attachments as media

### DIFF
--- a/src/components/ErrorButton.tsx
+++ b/src/components/ErrorButton.tsx
@@ -53,14 +53,17 @@ const IMG_TYPE = 'IMG_TYPE';
 const VIDEO_TYPE = 'VIDEO_TYPE';
 const UNKNOWN_TYPE = 'UNKNOWN_TYPE';
 
-const getFileType = (extName: string) => {
+const getFileType = (filePath: string = '', extName: string = '') => {
+  if (/^data:image\//i.test(filePath)) return IMG_TYPE;
+  if (/^data:video\//i.test(filePath)) return VIDEO_TYPE;
+
   if (imgSupportedFormats.includes(extName)) return IMG_TYPE;
   if (videoSupportFormats.includes(extName)) return VIDEO_TYPE;
   return UNKNOWN_TYPE;
 };
 
 const FileNode = ({ description, filePath, extName }: any) => {
-  const fileType = getFileType(extName.toLowerCase());
+  const fileType = getFileType(filePath, String(extName || '').toLowerCase());
   switch (fileType) {
     case IMG_TYPE:
       return <img alt={description} src={filePath} />;
@@ -108,7 +111,7 @@ function getModalConfig(
   return {
     title: `INFO FOR --> ${title}`,
     width: '80%',
-    maskClosable: true,
+    mask: { closable: true },
     content: (
       <Row style={{ flexDirection: 'column' }}>
         <Col span={24}>
@@ -128,8 +131,17 @@ function getModalConfig(
               <Row gutter={24}>
                 {caseAttachInfos.map((item) =>
                   item.filePath ? (
-                    <Col xs={24} sm={12} md={8}>
-                      <Card hoverable bordered cover={<FileNode {...item} />}>
+                    <Col
+                      key={`${item.filePath}-${item.createTime}`}
+                      xs={24}
+                      sm={12}
+                      md={8}
+                    >
+                      <Card
+                        hoverable
+                        variant='outlined'
+                        cover={<FileNode {...item} />}
+                      >
                         <Meta
                           title={
                             <>
@@ -151,7 +163,10 @@ function getModalConfig(
                       </Card>
                     </Col>
                   ) : (
-                    <Col span={24}>
+                    <Col
+                      key={`${item.description}-${item.createTime}`}
+                      span={24}
+                    >
                       <Row align='middle'>
                         <Col flex='none'>
                           <Tag icon={<FieldTimeOutlined />}>

--- a/test/components/testErrorButton.spec.js
+++ b/test/components/testErrorButton.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { ErrorButton } from '@/components/ErrorButton';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 describe('test error button component', () => {
   test('button should render when there has failureMessage', () => {
@@ -17,5 +17,28 @@ describe('test error button component', () => {
     };
     render(<ErrorButton {...props} />);
     expect(screen.queryByTestId('ErrorButton')).not.toBeInTheDocument();
+  });
+
+  test('renders base64 image attachments as images', async () => {
+    render(
+      <ErrorButton
+        fullName='base64 image case'
+        caseAttachInfos={[
+          {
+            filePath: 'data:image/png;base64,iVBORw0KGgo=',
+            description: 'base64 screenshot',
+            createTime: Date.now(),
+            extName: '',
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ErrorButton'));
+
+    const image = await screen.findByAltText('base64 screenshot');
+    expect(image).toBeInTheDocument();
+    expect(image.tagName).toBe('IMG');
+    expect(image).toHaveAttribute('src', 'data:image/png;base64,iVBORw0KGgo=');
   });
 });


### PR DESCRIPTION
## Summary
- detect data:image/* attachment paths and render them as images instead of file links
- detect data:video/* attachment paths for video previews
- make attachment rendering tolerant of missing extName values
- add regression coverage for base64 image attachments in the info modal

Fixes #324

## Tests
- /Users/harry.hou/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/jest/bin/jest.js test/components/testErrorButton.spec.js --runInBand --reporters=default
- /Users/harry.hou/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/typescript/bin/tsc -p build
- /Users/harry.hou/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/test.js --reporters=default