### PR TITLE
fix: display skipped tests instead of pending

### DIFF
--- a/src/components/DashBoard.tsx
+++ b/src/components/DashBoard.tsx
@@ -85,14 +85,14 @@ export const DashBoard = ({
   };
   const PendingTestSuites = {
     title: numPendingTestSuites,
-    content: 'Pending Suites',
+    content: 'Skipped Suites',
     label: `${getPercentage(numPendingTestSuites, numTotalTestSuites)} %`,
     labelColor: colorWarning,
     clickHandler: getScrollDownFunc(pendingTest),
   };
   const PendingTests = {
     title: numPendingTests,
-    content: 'Pending Tests',
+    content: 'Skipped Tests',
     label: `${getPercentage(numPendingTests, numTotalTests)} %`,
     labelColor: colorWarning,
     clickHandler: getScrollDownFunc(pendingTest),

--- a/src/components/DetailTable.tsx
+++ b/src/components/DetailTable.tsx
@@ -13,13 +13,14 @@ import {
   formatCollapsibleData,
   getFormatTimeDisplay,
   getRecordClass,
+  getStatusDisplayText,
   renderRootRowClass,
 } from '../utils/index';
 
 import {
   CheckOutlined,
   CloseOutlined,
-  Loading3QuartersOutlined,
+  MinusCircleOutlined,
   PushpinOutlined,
 } from '@ant-design/icons';
 
@@ -43,10 +44,11 @@ const renderStatus = ({
       );
       break;
     case 'pending':
+    case 'skipped':
       info = (
         <Text style={{ color: colorWarning }} strong >
-          <Loading3QuartersOutlined />
-          <span className='detail_status_text'>{status}</span>
+          <MinusCircleOutlined />
+          <span className='detail_status_text'>{getStatusDisplayText(status)}</span>
         </Text>
       );
       break;

--- a/src/components/MainTable.tsx
+++ b/src/components/MainTable.tsx
@@ -127,7 +127,7 @@ const getColumns = (
     filters: [
       { text: 'Passed', value: 'passed' },
       { text: 'Failed', value: 'failed' },
-      { text: 'Pending', value: 'pending' },
+      { text: 'Skipped', value: 'pending' },
       { text: 'Todo', value: 'todo' },
       { text: 'Not Passed', value: 'noPass' },
     ],

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,7 +1,9 @@
 import {
+  formatCollapsibleData,
   getExecutionResult,
   getExistKeys,
   getRecordClass,
+  getStatusDisplayText,
 } from './index';
 
 describe('Test Func  ==> `getRecordClass` :', () => {
@@ -19,11 +21,44 @@ describe('Test Func  ==> `getRecordClass` :', () => {
     expect(getRecordClass(state, 8)).toBe('row_pending-8')
   })
 
+  test('should return `row_pending` is state is skipped', () => {
+    const state = 'skipped'
+    expect(getRecordClass(state, 0)).toBe('row_pending-0')
+    expect(getRecordClass(state, 3)).toBe('row_pending-3')
+    expect(getRecordClass(state, 8)).toBe('row_pending-8')
+  })
+
   test('should return `row_todo` is state is todo', () => {
     const state = 'todo'
     expect(getRecordClass(state, 0)).toBe('row_todo-0')
     expect(getRecordClass(state, 1)).toBe('row_todo-1')
     expect(getRecordClass(state, 8)).toBe('row_todo-8')
+  })
+})
+
+describe('Test Func  ==> `getStatusDisplayText` :', () => {
+  test('should display pending and skipped statuses as skipped', () => {
+    expect(getStatusDisplayText('pending')).toBe('skipped')
+    expect(getStatusDisplayText('skipped')).toBe('skipped')
+  })
+
+  test('should keep other status display names', () => {
+    expect(getStatusDisplayText('passed')).toBe('passed')
+    expect(getStatusDisplayText('failed')).toBe('failed')
+    expect(getStatusDisplayText('todo')).toBe('todo')
+  })
+})
+
+describe('Test Func  ==> `formatCollapsibleData` :', () => {
+  test('should count pending and skipped statuses as pending test counts', () => {
+    const data = [
+      { ancestorTitles: ['group'], status: 'pending' },
+      { ancestorTitles: ['group'], status: 'skipped' },
+      { ancestorTitles: ['group'], status: 'passed' },
+    ]
+    const res = formatCollapsibleData(data, 1)
+    expect(res[0].numPendingTests).toBe(2)
+    expect(res[0].numPassingTests).toBe(1)
   })
 })
 

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -114,6 +114,12 @@ export const getFormattedTime = (start: number, end: number) => {
   return node;
 };
 
+export const isSkippedStatus = (status: string) =>
+  status === 'pending' || status === 'skipped';
+
+export const getStatusDisplayText = (status: string) =>
+  isSkippedStatus(status) ? 'skipped' : status;
+
 export const formatCollapsibleData = (
   data: IDetailTableProps['data'],
   groupLevel = 1
@@ -142,7 +148,7 @@ export const formatCollapsibleData = (
       tests,
       numFailingTests: tests.filter((item) => item.status === 'failed').length,
       numPassingTests: tests.filter((item) => item.status === 'passed').length,
-      numPendingTests: tests.filter((item) => item.status === 'pending').length,
+      numPendingTests: tests.filter((item) => isSkippedStatus(item.status)).length,
       numTodoTests: tests.filter((item) => item.status === 'todo').length,
     };
     rootArray.push(item);
@@ -188,7 +194,7 @@ export const getFormatTimeDisplay = (start: number, end: number) => {
 
 export const getRecordClass = (status: string, id: number) => {
   if (status === 'failed') return RowClassNames['row_failed'] + '-' + id;
-  if (status === 'pending') return RowClassNames['row_pending'] + '-' + id;
+  if (isSkippedStatus(status)) return RowClassNames['row_pending'] + '-' + id;
   if (status === 'todo') return RowClassNames['row_todo'] + '-' + id;
   return RowClassNames['row_passed'] + '-' + id;
 };

--- a/test/components/testDashBoard.spec.js
+++ b/test/components/testDashBoard.spec.js
@@ -35,4 +35,22 @@ describe('test Dashboard item number', () => {
     const myCardItems = screen.getAllByTestId('MyCardItem');
     expect(myCardItems.length).toEqual(6);
   });
+
+  test('pending counts should be labeled as skipped counts', () => {
+    const mockProps = {
+      numTotalTests: 3,
+      numTotalTestSuites: 3,
+      numFailedTestSuites: 0,
+      numFailedTests: 0,
+      numPendingTestSuites: 1,
+      numPendingTests: 1,
+      numRuntimeErrorTestSuites: 0,
+      testResults: [],
+    };
+    render(<DashBoard {...mockProps} />);
+    expect(screen.getByText('Skipped Suites')).toBeInTheDocument();
+    expect(screen.getByText('Skipped Tests')).toBeInTheDocument();
+    expect(screen.queryByText('Pending Suites')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pending Tests')).not.toBeInTheDocument();
+  });
 });

--- a/test/components/testDetailTable.spec.js
+++ b/test/components/testDetailTable.spec.js
@@ -51,6 +51,49 @@ test('Top level test in a file', async () => {
   expect(item).toBeInTheDocument();
 })
 
+test('Pending status should be displayed as skipped', async () => {
+  const title = 'pending test'
+  const mockProps = {
+    data: [
+      {
+        rowKey: 1214,
+        ancestorTitles: [],
+        fileAttachInfos: {},
+        fullName: title,
+        title,
+        status: 'pending',
+        duration: 2,
+        failureMessages: [],
+      },
+    ],
+  }
+  render(<DetailTable {...mockProps} />)
+  const item = await screen.findByText('skipped');
+  expect(item).toBeInTheDocument();
+  expect(screen.queryByText('pending')).not.toBeInTheDocument();
+})
+
+test('Skipped status should be displayed as skipped', async () => {
+  const title = 'skipped test'
+  const mockProps = {
+    data: [
+      {
+        rowKey: 1215,
+        ancestorTitles: [],
+        fileAttachInfos: {},
+        fullName: title,
+        title,
+        status: 'skipped',
+        duration: 2,
+        failureMessages: [],
+      },
+    ],
+  }
+  render(<DetailTable {...mockProps} />)
+  const item = await screen.findByText('skipped');
+  expect(item).toBeInTheDocument();
+})
+
 describe('Nested describes', () => {
   test('Top level test in a describe should be prepended by describe name', async () => {
     const describeTitle = 'Nested describes'


### PR DESCRIPTION
## Summary
- display Jest pending/skipped assertion statuses as skipped in the detail table
- relabel pending dashboard cards and status filter as skipped while keeping raw report data unchanged
- count explicit skipped statuses with pending/skipped grouped rows for compatibility

Fixes #325

## Tests
- /Users/harry.hou/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/test.js src/utils/index.test.js test/components/testDetailTable.spec.js test/components/testDashBoard.spec.js --runInBand --reporters=default
- /Users/harry.hou/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/typescript/bin/tsc -p build
- /Users/harry.hou/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/test.js --runInBand --reporters=default
- /Users/harry.hou/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/build.js
- /Users/harry.hou/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/test.js --config test/Examples/jest.pending-skip.config.js --runInBand