### PR TITLE
fix: label pending tests as skipped

### DIFF
--- a/src/components/DashBoard.tsx
+++ b/src/components/DashBoard.tsx
@@ -85,14 +85,14 @@ export const DashBoard = ({
   };
   const PendingTestSuites = {
     title: numPendingTestSuites,
-    content: 'Pending Suites',
+    content: 'Skipped Suites',
     label: `${getPercentage(numPendingTestSuites, numTotalTestSuites)} %`,
     labelColor: colorWarning,
     clickHandler: getScrollDownFunc(pendingTest),
   };
   const PendingTests = {
     title: numPendingTests,
-    content: 'Pending Tests',
+    content: 'Skipped Tests',
     label: `${getPercentage(numPendingTests, numTotalTests)} %`,
     labelColor: colorWarning,
     clickHandler: getScrollDownFunc(pendingTest),

--- a/src/components/DetailTable.tsx
+++ b/src/components/DetailTable.tsx
@@ -27,6 +27,9 @@ import { ErrorButton } from './ErrorButton';
 import { renderStatus as parentRowRenderStatus } from './MainTable';
 const { Text } = Typography;
 
+const getStatusText = (status: string) =>
+  status === 'pending' ? 'skipped' : status;
+
 const renderStatus = ({
   status,
   colorToken,
@@ -46,7 +49,7 @@ const renderStatus = ({
       info = (
         <Text style={{ color: colorWarning }} strong >
           <Loading3QuartersOutlined />
-          <span className='detail_status_text'>{status}</span>
+          <span className='detail_status_text'>{getStatusText(status)}</span>
         </Text>
       );
       break;

--- a/src/components/Information.tsx
+++ b/src/components/Information.tsx
@@ -92,7 +92,7 @@ const CustomTooltip = ({
       },
       {
         icon: <Loading3QuartersOutlined style={{ color: '#faad14' }} />,
-        title: 'Pending',
+        title: 'Skipped',
         content: numPendingTests,
       },
     ];

--- a/src/components/MainTable.tsx
+++ b/src/components/MainTable.tsx
@@ -127,7 +127,7 @@ const getColumns = (
     filters: [
       { text: 'Passed', value: 'passed' },
       { text: 'Failed', value: 'failed' },
-      { text: 'Pending', value: 'pending' },
+      { text: 'Skipped', value: 'pending' },
       { text: 'Todo', value: 'todo' },
       { text: 'Not Passed', value: 'noPass' },
     ],

--- a/test/components/testDashBoard.spec.js
+++ b/test/components/testDashBoard.spec.js
@@ -35,4 +35,22 @@ describe('test Dashboard item number', () => {
     const myCardItems = screen.getAllByTestId('MyCardItem');
     expect(myCardItems.length).toEqual(6);
   });
+
+  test('labels pending counts as skipped tests', () => {
+    const mockProps = {
+      numTotalTests: 3,
+      numTotalTestSuites: 3,
+      numFailedTestSuites: 0,
+      numFailedTests: 0,
+      numPendingTestSuites: 1,
+      numPendingTests: 1,
+      numRuntimeErrorTestSuites: 0,
+      testResults: [],
+    };
+    render(<DashBoard {...mockProps} />);
+    expect(screen.getByText('Skipped Suites')).toBeInTheDocument();
+    expect(screen.getByText('Skipped Tests')).toBeInTheDocument();
+    expect(screen.queryByText('Pending Suites')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pending Tests')).not.toBeInTheDocument();
+  });
 });

--- a/test/components/testDetailTable.spec.js
+++ b/test/components/testDetailTable.spec.js
@@ -51,6 +51,27 @@ test('Top level test in a file', async () => {
   expect(item).toBeInTheDocument();
 })
 
+test('pending test results are labeled as skipped', async () => {
+  const title = 'skipped test'
+  const mockProps = {
+    data: [
+      {
+        rowKey: 1214,
+        ancestorTitles: [],
+        fileAttachInfos: {},
+        fullName: title,
+        title,
+        status: 'pending',
+        duration: 2,
+        failureMessages: [],
+      },
+    ],
+  }
+  render(<DetailTable {...mockProps} />)
+  expect(await screen.findByText('skipped')).toBeInTheDocument();
+  expect(screen.queryByText('pending')).not.toBeInTheDocument();
+})
+
 describe('Nested describes', () => {
   test('Top level test in a describe should be prepended by describe name', async () => {
     const describeTitle = 'Nested describes'


### PR DESCRIPTION
Fixes #325.

## What changed

- Show Jest `pending` results as "skipped" in the report UI.
- Update dashboard cards, chart tooltip text, status filter text, and detail-row status text.
- Keep the underlying Jest status value as `pending` so existing filtering, row classes, and data processing continue to work.
- Add component coverage for the user-visible skipped labels.

## Why

Jest reports skipped tests with the `pending` assertion status, but showing that raw status in the HTML report is confusing. The report now uses the clearer user-facing label while preserving the original data model internally.

## Verification

- `tsc --noEmit`
- `tsc -p build`
- `git diff --check`

I also attempted the focused component tests locally, but the local Yarn install produced `@ant-design/icons-svg` without the JavaScript icon files that Ant Design imports, so Jest failed before reaching these assertions. CI should provide the clean environment signal.
